### PR TITLE
Fix 0.0.0 version metadata in installed dist-info

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,12 +12,13 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
     - python {{ python_min }}
-    - setuptools >=61.0
+    - setuptools >=77
+    - setuptools-scm >=8
     - pip
   run:
     - python >={{ python_min }}
@@ -32,6 +33,12 @@ test:
     - smoothify
   commands:
     - pip check
+    # Guards against setuptools-scm being absent from `host:`, which makes the
+    # build silently record version 0.0.0 in the installed dist-info. This must
+    # check importlib.metadata rather than smoothify.__version__: the latter
+    # reads _version.py, which ships pre-generated in the sdist and so stays
+    # correct even when the build is broken.
+    - python -c "from importlib.metadata import version; assert version('smoothify') == '{{ version }}', version('smoothify')"
   requires:
     - pip
     - python {{ python_min }}


### PR DESCRIPTION
Recipe-only fix — no version change, build number bumped to 1.

## The bug

`setuptools-scm` is missing from `host:`. Upstream sets `dynamic = ["version"]` with `setuptools-scm>=8` as the version source, and the recipe builds with `--no-build-isolation`, so build requirements must come from `host:`.

It does not fail the build. It silently records `0.0.0` in the installed dist-info. Verified against the 0.3.3 sdist in clean environments:

```
setuptools only             -> dist-info = '0.0.0'
setuptools + setuptools-scm -> dist-info = '0.3.3'
```

Every published build from **0.2.3 through 0.3.3** contains `site-packages/smoothify-0.0.0.dist-info`. So on conda:

```python
>>> from importlib.metadata import version
>>> version("smoothify")
'0.0.0'
```

while `conda list` correctly shows `0.3.3` — the conda package version comes from `meta.yaml` and is independent of the Python metadata, so nothing failed loudly.

Fixed by adding `setuptools-scm >=8` and raising `setuptools` to `>=77` to match upstream's `build-system.requires`.

## Impact is narrower here than it looks

**`smoothify.__version__` is correct and always has been.** Smoothify sets `version_file = "smoothify/_version.py"`, and the generated `_version.py` is shipped inside the sdist, so the conda build copies it through intact:

```
without scm -> _version.py = '0.3.3' | dist-info = '0.0.0'
with    scm -> _version.py = '0.3.3' | dist-info = '0.3.3'
```

So this affects pip-visible metadata only — `pip show smoothify`, `importlib.metadata.version(...)`, and anything resolving smoothify as a dependency in a mixed pip/conda environment. Users reading `smoothify.__version__` were never affected.

## The test asserts importlib.metadata, deliberately

Note the guard checks `importlib.metadata.version('smoothify')`, **not** `smoothify.__version__`:

```yaml
- python -c "from importlib.metadata import version; assert version('smoothify') == '{{ version }}', version('smoothify')"
```

Asserting `__version__` would pass while the bug is present, for the `_version.py` reason above — it would be a guard that never fires. Only the dist-info check detects this failure mode.

It also avoids importing the package, so it needs no additional entries under `test: requires:`.

## Diff

```diff
-  number: 0
+  number: 1

   host:
     - python {{ python_min }}
-    - setuptools >=61.0
+    - setuptools >=77
+    - setuptools-scm >=8
     - pip
```

Run requirements are unchanged — they already match upstream's `requires_dist` exactly (`geopandas`, `joblib`, `numpy`, `scipy`, `shapely`).

Same root cause as [multiclean-feedstock#8](https://github.com/conda-forge/multiclean-feedstock/pull/8) and [buildingregulariser-feedstock#10](https://github.com/conda-forge/buildingregulariser-feedstock/pull/10), both merged.